### PR TITLE
Dockerfile now creates build tools recognized by Setuptools.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v5.6.0
+======
+
+* Added jaraco.windows.msvc, containing a routine for
+  installing MSVC in a Docker image. Docker image now
+  builds with MSVC support.
+
 v5.5.0
 ======
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,19 +28,7 @@ RUN cmd /c 'certutil -generateSSTFromWU roots.sst && certutil -addstore -f root 
 RUN setx TOX_WORK_DIR \tox
 
 # Install Visual Studio
-RUN cmd /c start /w vs_buildtools --quiet --wait --norestart --nocache modify \
- --add Microsoft.VisualStudio.Component.CoreEditor \
- --add Microsoft.VisualStudio.Workload.CoreEditor \
- --add Microsoft.VisualStudio.Component.Roslyn.Compiler \
- --add Microsoft.Component.MSBuild \
- --add Microsoft.VisualStudio.Component.TextTemplating \
- --add Microsoft.VisualStudio.Component.VC.CoreIde \
- --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
- --add Microsoft.VisualStudio.Component.Windows10SDK.19041 \
- --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest \
- --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core \
- --add Microsoft.VisualStudio.Workload.NativeDesktop \
- --add Microsoft.VisualStudio.Workload.WDExpress
+RUN py -m pip-run -q git+https://github.com/jaraco/jaraco.windows@feature/dockerfile-compiler -- -m jaraco.windows.msvc
 
 RUN & \"${env:programfiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe\" -latest -prerelease -requiresAny -property installationPath -products *
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,20 +6,6 @@ FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
 # Download the Build Tools bootstrapper.
 ADD https://aka.ms/vs/16/release/vs_buildtools.exe vs_buildtools.exe
 
-# Install Visual Studio
-RUN ./vs_buildtools.exe --quiet --wait --norestart --nocache \
- --add Microsoft.VisualStudio.Component.CoreEditor \
- --add Microsoft.VisualStudio.Workload.CoreEditor \
- --add Microsoft.VisualStudio.Component.Roslyn.Compiler \
- --add Microsoft.Component.MSBuild \
- --add Microsoft.VisualStudio.Component.TextTemplating \
- --add Microsoft.VisualStudio.Component.VC.CoreIde \
- --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
- --add Microsoft.VisualStudio.Component.Windows10SDK.19041 \
- --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest \
- --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core \
- --add Microsoft.VisualStudio.Workload.NativeDesktop
-
 # Install chocolatey
 RUN powershell -c "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iwr https://chocolatey.org/install.ps1 -UseBasicParsing | iex"
 RUN choco feature enable -n allowGlobalConfirmation
@@ -40,5 +26,24 @@ RUN cmd /c 'certutil -generateSSTFromWU roots.sst && certutil -addstore -f root 
 
 
 RUN setx TOX_WORK_DIR \tox
+
+# Install Visual Studio
+RUN cmd /c start /w vs_buildtools --quiet --wait --norestart --nocache modify \
+ --add Microsoft.VisualStudio.Component.CoreEditor \
+ --add Microsoft.VisualStudio.Workload.CoreEditor \
+ --add Microsoft.VisualStudio.Component.Roslyn.Compiler \
+ --add Microsoft.Component.MSBuild \
+ --add Microsoft.VisualStudio.Component.TextTemplating \
+ --add Microsoft.VisualStudio.Component.VC.CoreIde \
+ --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
+ --add Microsoft.VisualStudio.Component.Windows10SDK.19041 \
+ --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest \
+ --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core \
+ --add Microsoft.VisualStudio.Workload.NativeDesktop \
+ --add Microsoft.VisualStudio.Workload.WDExpress
+
+RUN & \"${env:programfiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe\" -latest -prerelease -requiresAny -property installationPath -products *
+
+RUN py -c 'from setuptools import msvc; print(msvc._msvc14_find_vc2017())'
 
 ENTRYPOINT ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,10 @@ RUN pypy3 -m pip install -U pip
 # install certificates (https://bugs.python.org/issue36137#msg336806)
 RUN cmd /c 'certutil -generateSSTFromWU roots.sst && certutil -addstore -f root roots.sst && del roots.sst'
 
-
 RUN setx TOX_WORK_DIR \tox
 
 # Install Visual Studio
-RUN py -m pip-run -q git+https://github.com/jaraco/jaraco.windows@feature/dockerfile-compiler -- -m jaraco.windows.msvc
-
-RUN & \"${env:programfiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe\" -latest -prerelease -requiresAny -property installationPath -products *
-
-RUN py -c 'from setuptools import msvc; print(msvc._msvc14_find_vc2017())'
+COPY . jaraco.windows
+RUN py -m pip-run -q ./jaraco.windows -- -m jaraco.windows.msvc
 
 ENTRYPOINT ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,19 @@ FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
 # Download the Build Tools bootstrapper.
 ADD https://aka.ms/vs/16/release/vs_buildtools.exe vs_buildtools.exe
 
-# Install Build Tools with the Microsoft.VisualStudio.Workload.AzureBuildTools workload.
-# Exclude workloads and components with known issues.
-RUN ./vs_buildtools.exe --quiet --wait --norestart --nocache --installPath C:\BuildTools --add Microsoft.VisualStudio.Workload.AzureBuildTools --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 --remove Microsoft.VisualStudio.Component.Windows81SDK
+# Install Visual Studio
+RUN ./vs_buildtools.exe --quiet --wait --norestart --nocache \
+ --add Microsoft.VisualStudio.Component.CoreEditor \
+ --add Microsoft.VisualStudio.Workload.CoreEditor \
+ --add Microsoft.VisualStudio.Component.Roslyn.Compiler \
+ --add Microsoft.Component.MSBuild \
+ --add Microsoft.VisualStudio.Component.TextTemplating \
+ --add Microsoft.VisualStudio.Component.VC.CoreIde \
+ --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
+ --add Microsoft.VisualStudio.Component.Windows10SDK.19041 \
+ --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest \
+ --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core \
+ --add Microsoft.VisualStudio.Workload.NativeDesktop
 
 # Install chocolatey
 RUN powershell -c "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iwr https://chocolatey.org/install.ps1 -UseBasicParsing | iex"

--- a/jaraco/windows/filesystem/change.py
+++ b/jaraco/windows/filesystem/change.py
@@ -177,7 +177,7 @@ class Notifier(object):
 class BlockingNotifier(Notifier):
     @staticmethod
     def wait_results(*args):
-        """ calls WaitForMultipleObjects repeatedly with args """
+        """calls WaitForMultipleObjects repeatedly with args"""
         return itertools.starmap(event.WaitForMultipleObjects, itertools.repeat(args))
 
     def get_changed_files(self):

--- a/jaraco/windows/msvc.py
+++ b/jaraco/windows/msvc.py
@@ -9,8 +9,14 @@ default_components = [
 
 def install(components=default_components):
     cmd = [
-        'vs_buildtools', '--quiet', '--wait', '--norestart',
-        '--nocache', '--installPath', 'C:\\BuildTools']
+        'vs_buildtools',
+        '--quiet',
+        '--wait',
+        '--norestart',
+        '--nocache',
+        '--installPath',
+        'C:\\BuildTools',
+    ]
     for component in components:
         cmd += ['--add', component]
     res = subprocess.Popen(cmd).wait()

--- a/jaraco/windows/msvc.py
+++ b/jaraco/windows/msvc.py
@@ -1,0 +1,19 @@
+import subprocess
+
+
+default_components = [
+    'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+    'Microsoft.VisualStudio.Workload.WDExpress',
+]
+
+
+def install(components=default_components):
+    cmd = ['vs_buildtools', '--quiet', '--wait', '--norestart', '--nocache']
+    for component in components:
+        cmd += ['--add', component]
+    res = subprocess.Popen(cmd).wait()
+    if res != 3010:
+        raise SystemExit(res)
+
+
+__name__ == '__main__' and install()

--- a/jaraco/windows/msvc.py
+++ b/jaraco/windows/msvc.py
@@ -8,7 +8,9 @@ default_components = [
 
 
 def install(components=default_components):
-    cmd = ['vs_buildtools', '--quiet', '--wait', '--norestart', '--nocache']
+    cmd = [
+        'vs_buildtools', '--quiet', '--wait', '--norestart',
+        '--nocache', '--installPath', 'C:\\BuildTools']
     for component in components:
         cmd += ['--add', component]
     res = subprocess.Popen(cmd).wait()


### PR DESCRIPTION
- Use components from an export of a local install. Still, compiler is not recognized. Ref #21.
- Getting closer to identifying why setuptools doesn't see the build tools
- Add msvc module for installing MSVC using the command line.
- Use jaraco.windows to install the build tools. Gives better visibility and it's so much better than a cmd script.
- Try to include an installPath
- Build from local checkout. Remove debugging statements.

Fixes #21.